### PR TITLE
Export findExecutable (from util/index.ts).

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,3 +4,4 @@ import 'source-map-support/register';
 export * from './Runner';
 export * from './Builder';
 export * from './Downloader';
+export { findExecutable } from './util';


### PR DESCRIPTION
This is useful for external tools which wish to launch the same
executable as nwjs-builder-phoenix does.